### PR TITLE
Snapshot.cs and RepairSnapshot.cs

### DIFF
--- a/GraphicalVersion.csproj
+++ b/GraphicalVersion.csproj
@@ -1,0 +1,116 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{5FD20CBA-64E5-4168-A060-61D6991D7A35}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>GraphicalVersion</RootNamespace>
+    <AssemblyName>SnapshotConverter</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationIcon>1316800993_khexedit.ico</ApplicationIcon>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Windows.Presentation" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Deployment" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Form1.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Form1.Designer.cs">
+      <DependentUpon>Form1.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RepairSnapshot.cs" />
+    <Compile Include="Snapshot.cs" />
+    <EmbeddedResource Include="Form1.resx">
+      <DependentUpon>Form1.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Properties\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <Compile Include="Properties\Resources.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+    <None Include="Properties\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    </None>
+    <Compile Include="Properties\Settings.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="1316800993_khexedit.ico" />
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/GraphicalVersion.csproj.user
+++ b/GraphicalVersion.csproj.user
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishUrlHistory />
+    <InstallUrlHistory />
+    <SupportUrlHistory />
+    <UpdateUrlHistory />
+    <BootstrapperUrlHistory />
+    <ErrorReportUrlHistory />
+    <FallbackCulture>en-US</FallbackCulture>
+    <VerifyUploadedFiles>false</VerifyUploadedFiles>
+    <ProjectView>ProjectFiles</ProjectView>
+  </PropertyGroup>
+</Project>

--- a/RepairSnapshot.cs
+++ b/RepairSnapshot.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Runtime.InteropServices;
+using System.Diagnostics;
+
+namespace GraphicalVersion
+{
+    /// <summary>
+    /// Author: Andrew McCarthy
+    /// Class that attempts to repair broken Snapshot files prior to conversion, specifically 
+    /// those created using Access 2007 onwards
+    /// </summary>   
+	public static class RepairSnapshot
+    {
+
+        public static bool ProcessFile(string ucSnapshot)
+        {
+            //  Specify expected dmSpecVersion here.
+            byte[] dmSpecVersion = null;
+            dmSpecVersion = new byte[2] { 1, 4 };
+
+            // Define returnedVersion String
+            byte[] returnedVersion = null;
+            returnedVersion = new byte[2];
+
+            returnedVersion = ReadHeader(ucSnapshot, 52, 2);
+
+            //if (returnedVersion != dmSpecVersion)
+            if (ByteArrayCompare(returnedVersion, dmSpecVersion))
+            {
+                //  File looks OK.  No action required.
+                return true;
+            }
+
+            // Unexpected dmSpecVersion at offset 0x34
+            // Check 'wrong' offset for dmSpecVersion
+            returnedVersion = ReadHeader(ucSnapshot, 84, 2);
+
+            if (!ByteArrayCompare(returnedVersion, dmSpecVersion))
+            {
+                //  Unexpected dmSpecVersion at offset 0x54!
+                //  File might be corrupted or not an SNP.
+                return false;
+            }
+
+            //  Found dmSpecVersion at offset 0x54 - we can attempt a repair
+            //  Read in 200 bytes starting at offset 0x54
+            byte[] byteHeader = ReadHeader(ucSnapshot, 84, 200);
+
+            // Write the array back to the file at offset 0x34
+            WriteHeader(ucSnapshot, 52, byteHeader);
+
+            // Finished.  Return successfully.
+            return true;
+        }
+
+        private static Byte[] ReadHeader(string tempfile, int startOffset, int readLength)
+        {
+
+            using (BinaryReader fs = new BinaryReader(File.Open(tempfile, FileMode.Open)))
+            {
+                //Console.Write("File Size: ");
+                //Console.Write(fs.BaseStream.Length);
+                //Console.WriteLine(" bytes");
+                //Console.WriteLine("");
+
+                // Counter to be used in loop and to assign bytes to array
+                int b_arr = 0;
+
+                // Set offset to be start of the HEADER stream
+                int fileLength = (int)fs.BaseStream.Length;
+                int headerOffset = fileLength - 512;
+
+                // Set specified offset
+                int specOffset = headerOffset + startOffset;
+
+                // Set up reader
+                Byte[] readValue = null;
+                readValue = new Byte[readLength];
+
+                fs.BaseStream.Seek(specOffset, SeekOrigin.Begin);
+                while (readLength > b_arr)
+                {
+                    //Console.WriteLine("OK");
+                    readValue[b_arr] = fs.ReadByte();
+                    b_arr++;
+                }
+
+                fs.Close();
+                return readValue;
+            }
+
+        }
+
+        private static bool WriteHeader(string tempfile, int startOffset, byte[] writeArr)
+        {
+
+            using (BinaryReader fs = new BinaryReader(File.Open(tempfile, FileMode.Open)))
+            {
+                //Console.Write("File Size: ");
+                //Console.Write(fs.BaseStream.Length);
+                //Console.WriteLine(" bytes");
+                //Console.WriteLine("");
+
+                // Counter to be used in loop and to assign bytes to array
+                int b_arr = 0;
+
+                // Set offset to be start of the HEADER stream
+                int fileLength = (int)fs.BaseStream.Length;
+                int headerOffset = fileLength - 512;
+                int writeLength = writeArr.Length;
+
+                // Set specified offset
+                int specOffset = headerOffset + startOffset;
+
+                fs.BaseStream.Seek(specOffset, SeekOrigin.Begin);
+                while (writeLength > b_arr)
+                {
+                    fs.BaseStream.WriteByte(writeArr[b_arr]);
+                    b_arr++;
+                }
+
+                fs.Close();
+                return true;
+            }
+
+        }
+
+        private static bool ByteArrayCompare(byte[] a1, byte[] a2)
+        {
+            if (a1.Length != a2.Length)
+            {
+                // Console.WriteLine("Length Mismatch");
+                return false;
+            }
+            for (int i = 0; i < a1.Length; i++)
+                if (a1[i] != a2[i])
+                {
+                    // Console.WriteLine("Value Mismatch");
+                    return false;
+                }
+            return true;
+        }
+    }
+    
+}

--- a/Snapshot.cs
+++ b/Snapshot.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Runtime.InteropServices;
+using System.IO;
+
+namespace GraphicalVersion
+{
+
+    /// <summary>
+    /// Author: Jervis Muindi
+    /// Class that deals with conversion of snapshot files to PDFs. 
+    /// </summary>    
+    public static class Snapshot
+    {
+        /// <summary>
+        ///  Converts the SNP file in the given directory
+        /// </summary>
+        /// <param name="directory">The given directory. It should have a "\" a the end or otherwise directory won't be found</param>
+        /// <param name="compressedSnapshotName"></param>
+        /// <returns></returns>
+        public static bool convertToPDF(string directory, string compressedSnapshotName)
+        {
+            //Check that directory exists
+            if (!Directory.Exists(directory))
+            {
+                Console.WriteLine("Directory does not exist - " + directory);
+                return false;
+
+            }
+            else // the directory exists 
+            {
+                Directory.SetCurrentDirectory(directory);
+            }
+
+            // Ensure that the file exists
+            if (!File.Exists(Path.Combine(directory, compressedSnapshotName)))
+            {
+
+                Console.WriteLine("The following file does not exist : " + Path.Combine(directory, compressedSnapshotName));
+                return false;
+            }
+
+
+            string compressedFilepath = Path.Combine(directory, compressedSnapshotName);
+
+            string uncompressedSnapshot = getUncompressedSnapshot(compressedFilepath);  // get the full path of the uncompressed snapshot file
+
+            // Check and repair uncompressed Snapshot if necessary prior to conversion
+            bool result = RepairSnapshot.ProcessFile(uncompressedSnapshot);
+
+            // COULD DO - check previous result before moving on to conversion
+
+            result = convertToPDF(uncompressedSnapshot);
+
+            // TO DO - Delete the temporary file. 
+
+            // remove previous temp file if it exists already. 
+            if (File.Exists(uncompressedSnapshot))
+            {
+                FileInfo fi = new FileInfo(uncompressedSnapshot);
+                fi.Delete();
+                //Console.WriteLine("Temp File was deleted successfully"); // debuggin
+            }
+
+            return result;
+        }
+
+
+        public static string getUncompressedSnapshot(string compressedSnapshot)
+        {
+
+            if (!File.Exists(compressedSnapshot))
+            {
+                return null;
+            }
+
+
+
+            string dir = Path.GetDirectoryName(compressedSnapshot);
+            string tempName = Path.GetFileNameWithoutExtension(compressedSnapshot) + ".tmp";
+            string tempPath = Path.Combine(dir, tempName);
+
+
+            SetupDecompressOrCopyFile(compressedSnapshot, tempPath, 0);
+
+            //Console.WriteLine("temp path is " + tempPath); // debugging
+
+            return tempPath;
+
+        }
+
+
+
+        public static bool convertToPDF(string uncompressedSnapshotName)
+        {
+            string outputPDF = Path.GetFileNameWithoutExtension(uncompressedSnapshotName) + ".pdf";
+
+            /*
+             * The following string contains a path to a PDF file which doesn't exist
+             * This used in the MergePDFDocuments function below
+             */
+            string dummyPDF = Path.GetFileNameWithoutExtension(uncompressedSnapshotName) + "_dummy.pdf";
+
+            //SetDefaultPrinter("Fax");
+
+            bool r = false;
+            try
+            {
+                r = ConvertUncompressedSnapshot(uncompressedSnapshotName, outputPDF, 0, "", "", 0, 0, 0);
+                /*
+                 * ConvertUncompressedSnapshot function will produce a Secured PDF with random restrictions
+                 * 
+                 * This is a known issue.  A workaround is to call the MergePDFDocuments function using a
+                 * PDF that doesn't exist, as this will remove the security from the created PDF
+                 * 
+                 */
+                r = MergePDFDocuments(outputPDF, dummyPDF);
+            }
+            catch (DllNotFoundException)
+            {
+                Console.WriteLine("\nA required DLL was not found. Please make sure that the" +
+                                  "dynapdf.dll and StrStorage.dll both exist and are in the same folder as this executable and try again\n");
+                Environment.Exit(-1);
+            }
+
+            return r;
+        }
+
+        /*
+        public static bool convertToPDF(string uncompressedSnapshotName)
+        {
+            string outputPDF = Path.GetFileNameWithoutExtension(uncompressedSnapshotName) + ".pdf";
+            return ConvertUncompressedSnapshot(uncompressedSnapshotName, outputPDF, 0, "", "", 1, 0, 0);
+        }*/
+
+
+        [DllImport("setupapi.dll")]
+        public static extern int SetupDecompressOrCopyFile(string SourFileName, string TargetFileName, uint CompressionType);
+
+
+        /*
+         * In .Net 4.0 Calling the external library causes a stack imbalance error even though
+         * the specified parameters are correct for the unmanaged code function that we're calling. 
+         * 
+         * Use .Net 3.5 to get around this issue since in that runtime version, the framework will 
+         * auto-correct and resolve this imbalance error. 
+         * 
+         * See: http://codenition.blogspot.com/2010/05/pinvokestackimbalance-in-net-40i-beg.html
+         * 
+         */
+        //[DllImport("StrStorage.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("StrStorage.dll")]
+        public static extern bool ConvertUncompressedSnapshot(String uncompressedSnapshotName,
+                                                               String outputPDF,
+                                                               long compressionLevel,
+                                                               String passwordOpen,
+                                                               String passwordOwner,
+                                                               long passwordRestrictions,
+                                                               long PDFNoFontEmbedding,
+                                                               long PDFUnicodeFlags);
+        
+        [DllImport("StrStorage.dll")]
+        public static extern bool MergePDFDocuments(String firstPDF, String secondPDF);
+
+    }
+}


### PR DESCRIPTION
Added comments to Snapshot.cs for 'MergePDF' workaround to remove security from generated PDF file.

Created 'RepairSnapshot.cs' and added to project.  This class has a public function, 'ProcessFile' which checks for a corrupted DEVMODE structure in the Uncompressed Snapshot file and attempts to fix it prior to PDF conversion.  This fixes the Landscape/Cut-off page problem on converted PDFs.